### PR TITLE
Trying out the Unlicense

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,11 @@ In short:
 ## Public domain
 
 The project is in the public domain, and all contributions to it will be
-released as such.
+released as such. By submitting a pull request, you are agreeing to comply
+with the following contributor agreement:
+
+> I dedicate any and all copyright interest in this software to the
+> public domain. I make this dedication for the benefit of the public at
+> large and to the detriment of my heirs and successors. I intend this
+> dedication to be an overt act of relinquishment in perpetuity of all
+> present and future rights to this software under copyright law.

--- a/TERMS.txt
+++ b/TERMS.txt
@@ -1,6 +1,24 @@
-hmda_tools
+This is free and unencumbered software released into the public domain.
 
-Written by: Clinton Dreisbach, CFPB
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
 
-This software is released into the public domain. However, the author
-would appreciate credit if this program or parts of it are used.
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>


### PR DESCRIPTION
The [Unlicense](http://unlicense.org/) text seems to be a great model for putting software into the public domain. It is inspired by one of the most successful public domain software projects of all time, SQLite (which is probably both in your web browser and your cell phone.) It also seems to be used by a non-trivial amount of software.

Let's discuss using this not only for hmda-tools, but for more software in the future.
